### PR TITLE
게시판 api 만들기 - DATA rest 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/ancho/crud/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/ancho/crud/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.ancho.crud.repository;
 
 import com.ancho.crud.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/ancho/crud/repository/ArticleRepository.java
+++ b/src/main/java/com/ancho/crud/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.ancho.crud.repository;
 
 import com.ancho.crud.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,3 +29,4 @@ spring:
   data.rest:
       base-path: /api
       detection-strategy: annotated
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,3 +26,6 @@ spring:
     console:
       enabled: false
   sql.init.mode: always
+  data.rest:
+      base-path: /api
+      detection-strategy: annotated

--- a/src/test/java/com/ancho/crud/controller/DataRestTest.java
+++ b/src/test/java/com/ancho/crud/controller/DataRestTest.java
@@ -1,0 +1,90 @@
+package com.ancho.crud.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@DisplayName("Data Rest - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[API] 게시글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        //  Given
+
+        //  When & Then
+        mvc.perform(get("/api/articles"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(result ->  content().contentType(MediaType.valueOf("application/hal+json")));
+//                .andDo(print());  상세 내용 보여주는 코드
+    }
+
+
+    @DisplayName("[API] 게시글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticle_thenReturnsArticleJsonResponse() throws Exception {
+        //  Given
+
+        //  When & Then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(result ->  content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+
+    @DisplayName("[API] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnArticleCommentsJsonResponse() throws Exception {
+        //  Given
+
+        //  When & Then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(result ->  content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[API] 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        //  Given
+
+        //  When & Then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(result ->  content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+
+    @DisplayName("[API] 댓글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        //  Given
+
+        //  When & Then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(result ->  content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST 로 서비스하고, 해당 api 들의 존재 여부만 체크하도록 통합테스트 작성 