### PR TITLE
엔티티 코드 리팩토링 - equals(), hashcode() 에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/com/ancho/crud/domain/Article.java
+++ b/src/main/java/com/ancho/crud/domain/Article.java
@@ -87,7 +87,7 @@ public class Article extends AuditingFields{    //  상속을 통해 AuditingFie
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article that)) return false;
-        return id != null && id.equals(that.getId());
+        return this.getId() != null && this.getId().equals(that.getId());
         /*
          * "새로 만들어진 엔티티, 즉 영속화 되지 않은 엔티티는 동등성 검사에서 탈락시킬거야!"라는 뜻이다.
          * 글의 내용과 날짜와 같은 필드의 데이터들이 모두 동일할 지언정 id값이 없거나 동일하지 않다?
@@ -97,6 +97,6 @@ public class Article extends AuditingFields{    //  상속을 통해 AuditingFie
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/ancho/crud/domain/Article.java
+++ b/src/main/java/com/ancho/crud/domain/Article.java
@@ -32,7 +32,12 @@ public class Article extends AuditingFields{    //  상속을 통해 AuditingFie
     private Long id;    //  자동으로 부여
 
     @Setter @Column(nullable = false) private String title;   //  제목
-    @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
+
+    @Setter
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "userId")
+    private UserAccount userAccount; // 유저 정보 (ID)
+    
     @Setter @Column(nullable = false, length = 10000) private String content; //  본문
 
     @Setter private String hashtag; //  해시태그

--- a/src/main/java/com/ancho/crud/domain/ArticleComment.java
+++ b/src/main/java/com/ancho/crud/domain/ArticleComment.java
@@ -24,7 +24,12 @@ public class ArticleComment extends AuditingFields{
 
      //     연관 관계를 선언하기 위해 @ManyToOne 사용
      @Setter private @ManyToOne(optional = false) Article article;  //  게시글 (ID)
-     @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
+
+     @Setter
+     @ManyToOne(optional = false)
+     @JoinColumn(name = "userId")
+     private UserAccount userAccount; // 유저 정보 (ID)
+
      @Setter @Column(nullable = false, length = 500) private String content; //  본문
 
      protected ArticleComment() {}

--- a/src/main/java/com/ancho/crud/domain/ArticleComment.java
+++ b/src/main/java/com/ancho/crud/domain/ArticleComment.java
@@ -23,7 +23,9 @@ public class ArticleComment extends AuditingFields{
      private Long id;
 
      //     연관 관계를 선언하기 위해 @ManyToOne 사용
-     @Setter private @ManyToOne(optional = false) Article article;  //  게시글 (ID)
+     @Setter
+     @ManyToOne(optional = false)
+     private Article article;  //  게시글 (ID)
 
      @Setter
      @ManyToOne(optional = false)

--- a/src/main/java/com/ancho/crud/domain/ArticleComment.java
+++ b/src/main/java/com/ancho/crud/domain/ArticleComment.java
@@ -50,11 +50,11 @@ public class ArticleComment extends AuditingFields{
      public boolean equals(Object o) {
           if (this == o) return true;
           if (!(o instanceof ArticleComment that)) return false;
-          return id != null && id.equals(that.getId());
+          return this.getId() != null && this.getId().equals(that.getId());
      }
 
      @Override
      public int hashCode() {
-          return Objects.hash(id);
+          return Objects.hash(this.getId());
      }
 }

--- a/src/main/java/com/ancho/crud/domain/UserAccount.java
+++ b/src/main/java/com/ancho/crud/domain/UserAccount.java
@@ -43,11 +43,11 @@ public class UserAccount extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.getUserId());
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
이 pr은 엔티티의 `equals(), hashcode()` 가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.